### PR TITLE
Redirect book session button to experts page

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,27 +80,9 @@
                     <h1 class="mb-5">أُســـــرة أفضل مجتمـع أفضل</h1>
                     <p class="mt-4">استشارات أسرية ونفسية من نخبة من الخبراء، علشان كل خطوة تاخدها تكون بثقة ووعي.</p>
                     <div class="buttons mt-5">
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a href="html/Experts.html" class="btn btn-hero-one">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                         <button type="button" class="btn btn-hero-two" data-bs-toggle="modal"
                             data-bs-target="#staticBackdrop2">
                             تواصل معنا
@@ -224,27 +206,9 @@
                         <p class="mt-3 mb-4">نقدم استشارات متخصصة وبرامج تدريبية موجهة للأسرة، لمساعدتك على فهم
                             ديناميكيات العلاقات الأسرية، تحسين التواصل بين أفرادها، وحل النزاعات بشكل بناء، مما يؤدي إلى
                             أسرة أكثر ترابطًا وسعادة.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a href="html/Experts.html" class="btn btn-hero-one">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                     <div class="img col-lg-6">
                         <img src="imges/Father's Day-bro 1.png" alt="رسم توضيحي عائلي" loading="lazy" decoding="async">
@@ -259,28 +223,10 @@
                         <h1 class="mb-3">لبناء مجتمع داعم</h1>
                         <p class="mt-3 mb-4">أُسرة ليست مجرد منصة للخدمات، بل هي مجتمع متكامل يجمع الأفراد والخبراء.
                             نوفر مساحات آمنة للتفاعل وتبادل الخبرات، وورش عمل جماعية تعزز الشعور بالانتماء والدعم
-                            المتبادل، مما يسهم في بناء مجتمع أكثر وعيًا وتكافلاً.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                            المتبادل، مما يسهم في بناء مجتمع أكثر وتكافلاً.</p>
+                        <a href="html/Experts.html" class="btn btn-hero-one">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
                 <div
@@ -290,27 +236,9 @@
                         <p class="mt-3 mb-4">ندرك التحديات التي تواجه الأسر والمجتمعات اليوم. لذلك، نصمم برامجنا
                             وخدماتنا لتكون عملية، مرنة، وقابلة للتطبيق في حياتك اليومية، لمساعدتك على إحداث تغيير إيجابي
                             ومستدام.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a href="html/Experts.html" class="btn btn-hero-one">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                     <div class="img col-lg-6">
                         <img src="imges/Helping a partner-rafiki 1.png" alt="مساعدة شريك" loading="lazy"
@@ -331,27 +259,9 @@
                         <h1 class="mb-3">تعرف على خبرائنا</h1>
                         <p class="mt-3 mb-3">نقدم لك نخبة من الكوتش والاستشاريين المعتمدين، كل منهم متخصص في مجاله،
                             ومستعد لتقديم الدعم </p>
-                        <button type="button" class="btn btn-hero-two bg-white" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a href="html/Experts.html" class="btn btn-hero-two bg-white">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Redirect "Book Session" buttons to the experts page.

All "احجز جلسة" (Book Session) buttons on `index.html` now navigate directly to `html/Experts.html` instead of opening a modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca1f8435-501b-43b1-a0a5-88ca117f254f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca1f8435-501b-43b1-a0a5-88ca117f254f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

