### PR TITLE
Redirect book session button to experts page

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -116,7 +116,7 @@ class ExpertSystem {
                 <span>خبرة</span>
                 <span>${expert.experience}</span>
             </div>
-            <button class="btn btn-primary">احجز جلسة</button>
+            <a class="btn btn-primary" href="./Experts.html">احجز جلسة</a>
             <button class="btn btn-primary"><a href="./portflio.html"> عرض الملف الشخصي</a></button>
         `;
         return card;

--- a/index.html
+++ b/index.html
@@ -80,27 +80,9 @@
                     <h1 class="mb-5">أُســـــرة أفضل مجتمـع أفضل</h1>
                     <p class="mt-4">استشارات أسرية ونفسية من نخبة من الخبراء، علشان كل خطوة تاخدها تكون بثقة ووعي.</p>
                     <div class="buttons mt-5">
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-one" href="./html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                         <button type="button" class="btn btn-hero-two" data-bs-toggle="modal"
                             data-bs-target="#staticBackdrop2">
                             تواصل معنا
@@ -224,27 +206,9 @@
                         <p class="mt-3 mb-4">نقدم استشارات متخصصة وبرامج تدريبية موجهة للأسرة، لمساعدتك على فهم
                             ديناميكيات العلاقات الأسرية، تحسين التواصل بين أفرادها، وحل النزاعات بشكل بناء، مما يؤدي إلى
                             أسرة أكثر ترابطًا وسعادة.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-one" href="./html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                     <div class="img col-lg-6">
                         <img src="imges/Father's Day-bro 1.png" alt="رسم توضيحي عائلي" loading="lazy" decoding="async">
@@ -260,27 +224,9 @@
                         <p class="mt-3 mb-4">أُسرة ليست مجرد منصة للخدمات، بل هي مجتمع متكامل يجمع الأفراد والخبراء.
                             نوفر مساحات آمنة للتفاعل وتبادل الخبرات، وورش عمل جماعية تعزز الشعور بالانتماء والدعم
                             المتبادل، مما يسهم في بناء مجتمع أكثر وعيًا وتكافلاً.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-one" href="./html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
                 <div
@@ -331,27 +277,9 @@
                         <h1 class="mb-3">تعرف على خبرائنا</h1>
                         <p class="mt-3 mb-3">نقدم لك نخبة من الكوتش والاستشاريين المعتمدين، كل منهم متخصص في مجاله،
                             ومستعد لتقديم الدعم </p>
-                        <button type="button" class="btn btn-hero-two bg-white" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-two bg-white" href="./html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,7 +189,7 @@ class ExpertSystem {
                 <span>خبرة</span>
                 <span>${expert.experience}</span>
             </div>
-            <button class="btn btn-primary">احجز جلسة</button>
+            <a class="btn btn-primary" href="./Experts.html">احجز جلسة</a>
             <button class="btn btn-primary"><a href="./portflio.html"> عرض الملف الشخصي</a></button>
         `;
         


### PR DESCRIPTION
Redirect all "احجز جلسة" buttons to navigate to the experts page.

The previous behavior of these buttons opening a modal indicating no available appointments was replaced with direct navigation to the `./html/Experts.html` page, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f0b4eb5-20a1-43b7-93c3-712b17b30b61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f0b4eb5-20a1-43b7-93c3-712b17b30b61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

