### PR TITLE
Redirect book session button to experts page

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -116,9 +116,15 @@ class ExpertSystem {
                 <span>خبرة</span>
                 <span>${expert.experience}</span>
             </div>
-            <button class="btn btn-primary">احجز جلسة</button>
+            <button class="btn btn-primary book-session">احجز جلسة</button>
             <button class="btn btn-primary"><a href="./portflio.html"> عرض الملف الشخصي</a></button>
         `;
+        const bookButton = card.querySelector('.book-session');
+        if (bookButton) {
+            bookButton.addEventListener('click', () => {
+                window.location.href = './Experts.html';
+            });
+        }
         return card;
     }
     renderFallbackExperts() {
@@ -132,7 +138,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>15 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="family-counseling" data-experience="6-10" data-detailed-specialization="marriage-counseling" data-gender="female" data-service="family" data-communication="in-person">
@@ -143,7 +149,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>10 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="psychology" data-experience="3-5" data-detailed-specialization="family-therapy" data-gender="female" data-service="group" data-communication="online">
@@ -154,7 +160,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>7 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="personal-development" data-experience="20+" data-detailed-specialization="life-coaching" data-gender="male" data-service="individual" data-communication="both">
@@ -165,7 +171,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>25 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="family-counseling" data-experience="1-2" data-detailed-specialization="parenting" data-gender="female" data-service="family" data-communication="in-person">
@@ -176,11 +182,16 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>3 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
             `;
             this.expertCards = document.querySelectorAll('.expert');
+            document.querySelectorAll('.expert .book-session').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    window.location.href = './Experts.html';
+                });
+            });
         }
     }
     filterExperts() {

--- a/html/about.html
+++ b/html/about.html
@@ -201,27 +201,9 @@
                         <h1 class="mb-3">تعرف على خبرائنا</h1>
                         <p class="mt-3 mb-3">نقدم لك نخبة من الكوتش والاستشاريين المعتمدين، كل منهم متخصص في مجاله،
                             ومستعد لتقديم الدعم </p>
-                        <button type="button" class="btn btn-hero-two bg-white" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-two bg-white" href="./Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -80,27 +80,9 @@
                     <h1 class="mb-5">أُســـــرة أفضل مجتمـع أفضل</h1>
                     <p class="mt-4">استشارات أسرية ونفسية من نخبة من الخبراء، علشان كل خطوة تاخدها تكون بثقة ووعي.</p>
                     <div class="buttons mt-5">
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-one" href="html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                         <button type="button" class="btn btn-hero-two" data-bs-toggle="modal"
                             data-bs-target="#staticBackdrop2">
                             تواصل معنا
@@ -224,27 +206,9 @@
                         <p class="mt-3 mb-4">نقدم استشارات متخصصة وبرامج تدريبية موجهة للأسرة، لمساعدتك على فهم
                             ديناميكيات العلاقات الأسرية، تحسين التواصل بين أفرادها، وحل النزاعات بشكل بناء، مما يؤدي إلى
                             أسرة أكثر ترابطًا وسعادة.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-one" href="html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                     <div class="img col-lg-6">
                         <img src="imges/Father's Day-bro 1.png" alt="رسم توضيحي عائلي" loading="lazy" decoding="async">
@@ -260,27 +224,9 @@
                         <p class="mt-3 mb-4">أُسرة ليست مجرد منصة للخدمات، بل هي مجتمع متكامل يجمع الأفراد والخبراء.
                             نوفر مساحات آمنة للتفاعل وتبادل الخبرات، وورش عمل جماعية تعزز الشعور بالانتماء والدعم
                             المتبادل، مما يسهم في بناء مجتمع أكثر وعيًا وتكافلاً.</p>
-                        <button type="button" class="btn btn-hero-one" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-one" href="html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
                 <div
@@ -331,27 +277,9 @@
                         <h1 class="mb-3">تعرف على خبرائنا</h1>
                         <p class="mt-3 mb-3">نقدم لك نخبة من الكوتش والاستشاريين المعتمدين، كل منهم متخصص في مجاله،
                             ومستعد لتقديم الدعم </p>
-                        <button type="button" class="btn btn-hero-two bg-white" data-bs-toggle="modal"
-                            data-bs-target="#staticBackdrop">
+                        <a class="btn btn-hero-two bg-white" href="html/Experts.html">
                             أحجز جلسة
-                        </button>
-                        <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false"
-                            tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="staticBackdropLabel">حجز جلسة</h1>
-                                    </div>
-                                    <div class="modal-body">
-                                        <h5>"عذرًا، لا توجد مواعيد متاحة في الوقت الحالي."</h5>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary"
-                                            data-bs-dismiss="modal">إغلاق</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,10 +189,17 @@ class ExpertSystem {
                 <span>خبرة</span>
                 <span>${expert.experience}</span>
             </div>
-            <button class="btn btn-primary">احجز جلسة</button>
+            <button class="btn btn-primary book-session">احجز جلسة</button>
             <button class="btn btn-primary"><a href="./portflio.html"> عرض الملف الشخصي</a></button>
         `;
         
+        // Attach navigation for book session button
+        const bookButton = card.querySelector('.book-session') as HTMLButtonElement | null;
+        if (bookButton) {
+            bookButton.addEventListener('click', () => {
+                window.location.href = './Experts.html';
+            });
+        }
 
         return card;
     }
@@ -209,7 +216,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>15 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="family-counseling" data-experience="6-10" data-detailed-specialization="marriage-counseling" data-gender="female" data-service="family" data-communication="in-person">
@@ -220,7 +227,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>10 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="psychology" data-experience="3-5" data-detailed-specialization="family-therapy" data-gender="female" data-service="group" data-communication="online">
@@ -231,7 +238,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>7 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="personal-development" data-experience="20+" data-detailed-specialization="life-coaching" data-gender="male" data-service="individual" data-communication="both">
@@ -242,7 +249,7 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>25 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
                 <div class="expert" data-specialization="family-counseling" data-experience="1-2" data-detailed-specialization="parenting" data-gender="female" data-service="family" data-communication="in-person">
@@ -253,13 +260,20 @@ class ExpertSystem {
                         <span>خبرة</span>
                         <span>3 سنوات</span>
                     </div>
-                    <button class="btn btn-primary">احجز جلسة</button>
+                    <button class="btn btn-primary book-session">احجز جلسة</button>
                     <button class="btn btn-primary"><a href="#"> عرض الملف الشخصي</a></button>
                 </div>
             `;
             
             // Update expert cards reference after fallback rendering
             this.expertCards = document.querySelectorAll('.expert') as NodeListOf<ExpertCard>;
+
+            // Wire up fallback "book session" buttons
+            document.querySelectorAll('.expert .book-session').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    window.location.href = './Experts.html';
+                });
+            });
         }
     }
 


### PR DESCRIPTION
Direct all "احجز جلسة" (Book a session) buttons to the experts page.

Previously, these buttons either triggered a modal stating no appointments were available or lacked specific navigation. This change ensures a consistent user experience by linking all "Book a session" calls to the `Experts.html` page.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a467804-a532-429e-92de-a25bdcb6eba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a467804-a532-429e-92de-a25bdcb6eba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

